### PR TITLE
Report NV size correctly and zero read buffer

### DIFF
--- a/src/plat/api/nvmem.rs
+++ b/src/plat/api/nvmem.rs
@@ -93,6 +93,7 @@ impl MsTpm20RefPlatformImpl {
         {
             Some(region) => buf.copy_from_slice(region),
             None => {
+                buf.fill(0);
                 return Err(NvError::InvalidAccess {
                     start_offset,
                     len: buf.len(),
@@ -185,6 +186,13 @@ impl MsTpm20RefPlatformImpl {
         self.callbacks
             .commit_nv_state(&self.state.nvmem.region)
             .map_err(Error::PlatformCallback)
+    }
+
+    fn nv_size(&self) -> usize {
+        self.state
+            .nvmem
+            .region
+            .len()
     }
 }
 
@@ -359,6 +367,6 @@ mod c_api {
     #[no_mangle]
     #[tracing::instrument(level = "trace", ret)]
     pub unsafe extern "C" fn _plat__GetNvSize() -> u32 {
-        super::NV_MEMORY_SIZE as u32
+        platform!().nv_size() as u32
     }
 }


### PR DESCRIPTION
`_plat__GetNvSize` unconditionally returns 32k, but the actual NVRAM backing store may be smaller.
Also, if `nv_memory_read` fails due to a read past the end of the actual NVRAM backing, its caller may read junk out of the buffer; address that by zeroing the buffer before returning.