### PR TITLE
Add cold-init with size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod tpmlib_state;
 pub use error::DynResult;
 pub use error::Error;
 pub use plat::api::nvmem::NvError;
+pub use plat::api::nvmem::NV_MEMORY_SIZE;
 pub use plat::MsTpm20RefPlatform;
 pub use plat::MsTpm20RefRuntimeState;
 
@@ -21,6 +22,9 @@ pub enum InitKind<'a> {
     /// Initialize the TPM entirely from scratch, having it manufacture an
     /// initial nvmem blob.
     ColdInit,
+    /// Initialize the TPM entirely from scratch, having it manufacture an
+    /// initial nvmem blob of the provided size.
+    ColdInitWithSize(usize),
     /// Initialize the TPM from an existing saved nvmem blob.
     ColdInitWithPersistentState {
         /// Opaque nvmem blob
@@ -32,6 +36,7 @@ impl core::fmt::Debug for InitKind<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InitKind::ColdInit => write!(f, "ColdInit"),
+            InitKind::ColdInitWithSize(size) => write!(f, "ColdInitWithSize({})", size),
             InitKind::ColdInitWithPersistentState { .. } => {
                 write!(f, "ColdInitWithPersistentState {{ .. }}")
             }

--- a/src/plat/api/nvmem.rs
+++ b/src/plat/api/nvmem.rs
@@ -18,9 +18,9 @@ pub struct NvState {
 }
 
 impl NvState {
-    pub fn new() -> NvState {
+    pub fn new(size: usize) -> NvState {
         NvState {
-            region: Vec::new(),
+            region: vec![0; size],
             is_init: false,
         }
     }
@@ -64,10 +64,10 @@ impl MsTpm20RefPlatformImpl {
 }
 
 impl MsTpm20RefPlatformImpl {
-    pub fn nv_enable(&mut self, size: usize) -> Result<(), Error> {
+    pub fn nv_enable(&mut self) -> Result<(), Error> {
         if !self.state.nvmem.is_init {
             tracing::debug!("calling __plat_NvEnable before `nv_enable_from_blob` was called");
-            self.state.nvmem.region = vec![0; size];
+            self.state.nvmem.region = vec![0; self.nv_size()];
             self.state.nvmem.is_init = true;
         }
 
@@ -198,7 +198,6 @@ impl MsTpm20RefPlatformImpl {
 
 mod c_api {
     use core::ffi::c_void;
-    use super::NV_MEMORY_SIZE;
 
     // NOTE: The commented out functions are only ever called from the simulator,
     // and as such, they really shouldn't have been specified as part of the the
@@ -215,7 +214,7 @@ mod c_api {
     #[no_mangle]
     #[tracing::instrument(level = "trace", ret)]
     pub unsafe extern "C" fn _plat__NVEnable(plat_parameter: *mut c_void) -> i32 {
-        match platform!().nv_enable(NV_MEMORY_SIZE) {
+        match platform!().nv_enable() {
             Ok(()) => 0,
             Err(e) => {
                 tracing::error!("error calling _plat__NVEnable({:?}): {}", plat_parameter, e);

--- a/src/plat/api/nvmem.rs
+++ b/src/plat/api/nvmem.rs
@@ -9,7 +9,7 @@ use crate::error::Error;
 
 use super::super::MsTpm20RefPlatformImpl;
 
-const NV_MEMORY_SIZE: usize = 0x8000;
+pub const NV_MEMORY_SIZE: usize = 0x8000;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct NvState {
@@ -64,10 +64,10 @@ impl MsTpm20RefPlatformImpl {
 }
 
 impl MsTpm20RefPlatformImpl {
-    pub fn nv_enable(&mut self) -> Result<(), Error> {
+    pub fn nv_enable(&mut self, size: usize) -> Result<(), Error> {
         if !self.state.nvmem.is_init {
             tracing::debug!("calling __plat_NvEnable before `nv_enable_from_blob` was called");
-            self.state.nvmem.region = vec![0; NV_MEMORY_SIZE];
+            self.state.nvmem.region = vec![0; size];
             self.state.nvmem.is_init = true;
         }
 
@@ -198,6 +198,7 @@ impl MsTpm20RefPlatformImpl {
 
 mod c_api {
     use core::ffi::c_void;
+    use super::NV_MEMORY_SIZE;
 
     // NOTE: The commented out functions are only ever called from the simulator,
     // and as such, they really shouldn't have been specified as part of the the
@@ -214,7 +215,7 @@ mod c_api {
     #[no_mangle]
     #[tracing::instrument(level = "trace", ret)]
     pub unsafe extern "C" fn _plat__NVEnable(plat_parameter: *mut c_void) -> i32 {
-        match platform!().nv_enable() {
+        match platform!().nv_enable(NV_MEMORY_SIZE) {
             Ok(()) => 0,
             Err(e) => {
                 tracing::error!("error calling _plat__NVEnable({:?}): {}", plat_parameter, e);

--- a/src/plat/api/power_plat.rs
+++ b/src/plat/api/power_plat.rs
@@ -7,7 +7,6 @@ use serde::Serialize;
 
 use crate::error::Error;
 
-use super::nvmem::NV_MEMORY_SIZE;
 use super::super::MsTpm20RefPlatformImpl;
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -25,7 +24,7 @@ impl MsTpm20RefPlatformImpl {
     pub fn signal_power_on(&mut self) -> Result<(), Error> {
         self.timer_reset();
         self.state.power_plat.power_lost = true;
-        self.nv_enable(NV_MEMORY_SIZE)?;
+        self.nv_enable()?;
         Ok(())
     }
 

--- a/src/plat/api/power_plat.rs
+++ b/src/plat/api/power_plat.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 
 use crate::error::Error;
 
+use super::nvmem::NV_MEMORY_SIZE;
 use super::super::MsTpm20RefPlatformImpl;
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -24,7 +25,7 @@ impl MsTpm20RefPlatformImpl {
     pub fn signal_power_on(&mut self) -> Result<(), Error> {
         self.timer_reset();
         self.state.power_plat.power_lost = true;
-        self.nv_enable()?;
+        self.nv_enable(NV_MEMORY_SIZE)?;
         Ok(())
     }
 

--- a/src/plat/mod.rs
+++ b/src/plat/mod.rs
@@ -150,6 +150,12 @@ impl MsTpm20RefPlatform {
         })
     }
 
+    pub fn nv_size(&self) -> u32 {
+        let mut platform = PLATFORM.try_lock().unwrap();
+        let platform = platform.as_mut().unwrap();
+        platform.state.nvmem.region.len() as u32
+    }
+
     /// Reset the TPM device (i.e: simulate power off + power on)
     pub fn reset(&mut self, with_new_nvmem_blob: Option<&[u8]>) -> Result<(), Error> {
         tracing::trace!("Resetting TPM library...");

--- a/src/plat/mod.rs
+++ b/src/plat/mod.rs
@@ -105,7 +105,8 @@ impl MsTpm20RefPlatform {
             None => {
                 let mut platform = MsTpm20RefPlatformImpl::new(callbacks);
                 match &init_kind {
-                    InitKind::ColdInit => platform.nv_enable()?,
+                    InitKind::ColdInit => platform.nv_enable(api::nvmem::NV_MEMORY_SIZE)?,
+                    InitKind::ColdInitWithSize(size) => platform.nv_enable(*size)?,
                     InitKind::ColdInitWithPersistentState { nvmem_blob } => {
                         platform.nv_enable_from_blob(nvmem_blob)?
                     }
@@ -126,7 +127,7 @@ impl MsTpm20RefPlatform {
         // platform, and Rust's std mutex is not reentrant!
         drop(maybe_platform);
 
-        if matches!(&init_kind, InitKind::ColdInit) {
+        if matches!(&init_kind, InitKind::ColdInit | InitKind::ColdInitWithSize(_)) {
             // SAFETY: TPM_Manufacture doesn't have any preconditions
             let ret = unsafe { ffi::TPM_Manufacture(true as i32) };
             if ret != 0 {

--- a/src/plat/mod.rs
+++ b/src/plat/mod.rs
@@ -150,12 +150,6 @@ impl MsTpm20RefPlatform {
         })
     }
 
-    pub fn nv_size(&self) -> u32 {
-        let mut platform = PLATFORM.try_lock().unwrap();
-        let platform = platform.as_mut().unwrap();
-        platform.state.nvmem.region.len() as u32
-    }
-
     /// Reset the TPM device (i.e: simulate power off + power on)
     pub fn reset(&mut self, with_new_nvmem_blob: Option<&[u8]>) -> Result<(), Error> {
         tracing::trace!("Resetting TPM library...");

--- a/src/plat/mod.rs
+++ b/src/plat/mod.rs
@@ -103,12 +103,21 @@ impl MsTpm20RefPlatform {
         match &mut *maybe_platform {
             Some(_platform) => return Err(Error::AlreadyInitialized),
             None => {
-                let mut platform = MsTpm20RefPlatformImpl::new(callbacks);
-                match &init_kind {
-                    InitKind::ColdInit => platform.nv_enable(api::nvmem::NV_MEMORY_SIZE)?,
-                    InitKind::ColdInitWithSize(size) => platform.nv_enable(*size)?,
+                let platform = match &init_kind {
+                    InitKind::ColdInit => {
+                        let mut platform = MsTpm20RefPlatformImpl::new(callbacks, api::nvmem::NV_MEMORY_SIZE);
+                        platform.nv_enable()?;
+                        platform
+                    }
+                    InitKind::ColdInitWithSize(size) => {
+                        let mut platform = MsTpm20RefPlatformImpl::new(callbacks, *size);
+                        platform.nv_enable()?;
+                        platform
+                    }
                     InitKind::ColdInitWithPersistentState { nvmem_blob } => {
-                        platform.nv_enable_from_blob(nvmem_blob)?
+                        let mut platform = MsTpm20RefPlatformImpl::new(callbacks, nvmem_blob.len());
+                        platform.nv_enable_from_blob(nvmem_blob)?;
+                        platform
                     }
                 };
                 *maybe_platform = Some(platform);
@@ -338,13 +347,13 @@ struct MsTpm20PlatformState {
 }
 
 impl MsTpm20PlatformState {
-    fn new() -> MsTpm20PlatformState {
+    fn new(size: usize) -> MsTpm20PlatformState {
         MsTpm20PlatformState {
             cancel: api::cancel::CancelState::new(),
             locality: api::locality_plat::LocalityState::new(),
             clock: api::clock::ClockState::new(),
             power_plat: api::power_plat::PowerPlatState::new(),
-            nvmem: api::nvmem::NvState::new(),
+            nvmem: api::nvmem::NvState::new(size),
         }
     }
 }
@@ -355,10 +364,10 @@ struct MsTpm20RefPlatformImpl {
 }
 
 impl MsTpm20RefPlatformImpl {
-    fn new(callbacks: Box<dyn PlatformCallbacks + Send>) -> MsTpm20RefPlatformImpl {
+    fn new(callbacks: Box<dyn PlatformCallbacks + Send>, size: usize) -> MsTpm20RefPlatformImpl {
         MsTpm20RefPlatformImpl {
             callbacks,
-            state: MsTpm20PlatformState::new(),
+            state: MsTpm20PlatformState::new(size),
         }
     }
 


### PR DESCRIPTION
OpenHCL live-servicing needs the ability to initialize the TPM with a given size instead of the default. Add a ColdInitWithSize InitKind that can do just that.